### PR TITLE
Types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,5 @@ jobs:
         run: npm install
       - name: Run linter
         run: npm run lint
+      - name: Type check
+        run: npm run test:types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node: [22, 24]
+        node: [22, 24, 26]
     services:
       postgres:
         image: postgres:17

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,40 @@
+declare function createLeaderElector (
+  options: createLeaderElector.LeaderElectorOptions
+): createLeaderElector.LeaderElector
+
+declare namespace createLeaderElector {
+  export interface Pool {
+    connect (): Promise<unknown>
+    query (text: string, ...args: unknown[]): Promise<unknown>
+  }
+
+  export interface Logger {
+    info: (...args: unknown[]) => void
+    debug: (...args: unknown[]) => void
+    warn: (...args: unknown[]) => void
+    error: (...args: unknown[]) => void
+  }
+
+  export interface NotificationChannel<TPayload = unknown> {
+    channel: string
+    onNotification: (payload: TPayload) => void | Promise<void>
+  }
+
+  export interface LeaderElectorOptions {
+    pool: Pool
+    lock: number
+    poll?: number
+    channels?: NotificationChannel[]
+    log?: Logger
+    onLeadershipChange?: ((isLeader: boolean) => void) | null
+  }
+
+  export interface LeaderElector {
+    start (): Promise<void>
+    stop (): Promise<void>
+    notify (payload: unknown, channelName: string): Promise<void>
+    isLeader (): boolean
+  }
+}
+
+export = createLeaderElector

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.2.0",
   "description": "PostgreSQL advisory lock-based leader election with notification channels",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "node --test test/*.test.js",
+    "test:types": "tsc -p tsconfig.json",
     "lint": "standard ."
   },
   "dependencies": {
@@ -12,7 +14,8 @@
     "pino": "^10.3.1"
   },
   "devDependencies": {
-    "standard": "^17.1.2"
+    "standard": "^17.1.2",
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -1,0 +1,36 @@
+import createLeaderElector = require('../index')
+
+const fakePool: createLeaderElector.Pool = {
+  connect: async () => ({}),
+  query: async () => ({})
+}
+
+const elector: createLeaderElector.LeaderElector = createLeaderElector({
+  pool: fakePool,
+  lock: 42,
+  poll: 1000,
+  channels: [
+    {
+      channel: 'deferred_messages',
+      onNotification: async (payload: unknown) => { void payload }
+    }
+  ],
+  log: {
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {}
+  },
+  onLeadershipChange: (isLeader: boolean) => { void isLeader }
+})
+
+const _minimal: createLeaderElector.LeaderElector = createLeaderElector({
+  pool: fakePool,
+  lock: 1
+})
+
+const _start: Promise<void> = elector.start()
+const _stop: Promise<void> = elector.stop()
+const _notify: Promise<void> = elector.notify({ id: 1 }, 'channel')
+const _isLeader: boolean = elector.isLeader()
+void _minimal; void _start; void _stop; void _notify; void _isLeader

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "esnext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.d.ts", "test/types.test-d.ts"]
+}


### PR DESCRIPTION
Adds TypeScript type declarations to `@platformatic/leader`. The package is JS-only, and consumers on TypeScript 6 hit `TS7016: Could not find a declaration file for module '@platformatic/leader'` (TS 6 tightened the implicit-`any` fallback that TS 5 used to allow). This was surfaced by the typescript-v6 bump in [platformatic/platformatic-world#41](https://github.com/platformatic/platformatic-world/pull/41); shipping types here unblocks it.

Changes:

- `index.d.ts` — `export = createLeaderElector` + `declare namespace` with `Pool`, `Logger`, `NotificationChannel`, `LeaderElectorOptions`, `LeaderElector`. `Pool` is a minimal structural type so the package's `.d.ts` doesn't pull in `@types/pg` or `pino` as peer-type requirements.
- `package.json` — `"types": "index.d.ts"`, new `test:types` script (`tsc -p tsconfig.json`), `typescript` devDep.
- `tsconfig.json` — strict, `noEmit`, nodenext, scoped to `index.d.ts` + the smoke.
- `test/types.test-d.ts` — usage smoke (default-import, minimal + full options, returned methods). `.test-d.ts` suffix keeps it out of `node --test test/*.test.js`.
- `.github/workflows/ci.yml` — explicit `Type check` step in the `lint` job (`npm run test:types`); added Node 26 to the test matrix.

Verified locally: `npm run test:types` passes under both TypeScript 5.9 and 6.0; `npm test` on Node 22/24/26; running the workflow build in `platformatic-world` against TS 6 with the new types no longer errors.
